### PR TITLE
Widescreen: Refactor, Fix WM mesh cull glitch, Fix crash bug

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -507,18 +507,24 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 				switch (LOWORD(wParam))
 				{
 				case VK_LEFT:
-					ffnx_trace("aspect_ratio: %d => %d\n", aspect_ratio, aspect_ratio - 1 >= 0 ? aspect_ratio - 1 : (AR_COUNT - 1) - 1);
+					if(aspect_ratio >= 0 && aspect_ratio < AR_COUNT - 1)
+					{
+						ffnx_trace("aspect_ratio: %d => %d\n", aspect_ratio, aspect_ratio - 1 >= 0 ? aspect_ratio - 1 : (AR_COUNT - 1) - 1);
 
-					aspect_ratio = aspect_ratio - 1 >= 0 ? aspect_ratio - 1 : (AR_COUNT - 1) - 1;
+						aspect_ratio = aspect_ratio - 1 >= 0 ? aspect_ratio - 1 : (AR_COUNT - 1) - 1;
 
-					newRenderer.reset();
+						newRenderer.reset();
+					}
 					break;
 				case VK_RIGHT:
-					ffnx_trace("aspect_ratio: %d => %d\n", aspect_ratio, (aspect_ratio + 1) % (AR_COUNT - 1));
+					if(aspect_ratio >= 0 && aspect_ratio < AR_COUNT - 1)
+					{
+						ffnx_trace("aspect_ratio: %d => %d\n", aspect_ratio, (aspect_ratio + 1) % (AR_COUNT - 1));
 
-					aspect_ratio = (aspect_ratio + 1) % (AR_COUNT - 1);
+						aspect_ratio = (aspect_ratio + 1) % (AR_COUNT - 1);
 
-					newRenderer.reset();
+						newRenderer.reset();
+					}
 					break;
 				case VK_RETURN:
 					if (!fullscreen)

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -507,16 +507,16 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 				switch (LOWORD(wParam))
 				{
 				case VK_LEFT:
-					ffnx_trace("aspect_ratio: %d => %d\n", aspect_ratio, aspect_ratio - 1 >= 0 ? aspect_ratio - 1 : AR_COUNT - 1);
+					ffnx_trace("aspect_ratio: %d => %d\n", aspect_ratio, aspect_ratio - 1 >= 0 ? aspect_ratio - 1 : (AR_COUNT - 1) - 1);
 
-					aspect_ratio = aspect_ratio - 1 >= 0 ? aspect_ratio - 1 : AR_COUNT - 1;
+					aspect_ratio = aspect_ratio - 1 >= 0 ? aspect_ratio - 1 : (AR_COUNT - 1) - 1;
 
 					newRenderer.reset();
 					break;
 				case VK_RIGHT:
-					ffnx_trace("aspect_ratio: %d => %d\n", aspect_ratio, (aspect_ratio + 1) % AR_COUNT);
+					ffnx_trace("aspect_ratio: %d => %d\n", aspect_ratio, (aspect_ratio + 1) % (AR_COUNT - 1));
 
-					aspect_ratio = (aspect_ratio + 1) % AR_COUNT;
+					aspect_ratio = (aspect_ratio + 1) % (AR_COUNT - 1);
 
 					newRenderer.reset();
 					break;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2952,6 +2952,7 @@ struct ff7_externals
 	uint32_t world_sub_75079D;
 	uint32_t world_sub_751EFC;
 	uint32_t world_culling_bg_meshes_75F263;
+	uint32_t world_submit_draw_bg_meshes_75F68C;
 	uint32_t world_compute_skybox_data_754100;
 	uint32_t world_submit_draw_clouds_and_meteor_7547A6;
 

--- a/src/ff7/battle.cpp
+++ b/src/ff7/battle.cpp
@@ -22,6 +22,7 @@
 #include "../ff7.h"
 #include "../log.h"
 #include "../achievement.h"
+#include "widescreen.h"
 
 void magic_thread_start(void (*func)())
 {
@@ -60,13 +61,11 @@ void ff7_display_battle_action_text_sub_6D71FA(short command_id, short action_id
 
 void ifrit_first_wave_effect_widescreen_fix_sub_66A47E(int wave_data_pointer) {
     if(aspect_ratio == AR_WIDESCREEN) {
-        constexpr int viewport_x_fix = -106;
-        constexpr int viewport_y_fix = 480 - 332;
-        constexpr int viewport_width_1_fix = 340 - 255;
-        *(short*)(wave_data_pointer + 8) += + viewport_x_fix;
-        *(short*)(wave_data_pointer + 16) += + viewport_x_fix + viewport_width_1_fix * 2;
-        *(short*)(wave_data_pointer + 24) += + viewport_x_fix;
-        *(short*)(wave_data_pointer + 32) += + viewport_x_fix + viewport_width_1_fix * 2;
+        int viewport_width_1_fix = ceil(255.f / game_width * wide_viewport_width) - 255;
+        *(short*)(wave_data_pointer + 8) += wide_viewport_x;
+        *(short*)(wave_data_pointer + 16) += wide_viewport_x + viewport_width_1_fix * 2;
+        *(short*)(wave_data_pointer + 24) += wide_viewport_x;
+        *(short*)(wave_data_pointer + 32) += wide_viewport_x + viewport_width_1_fix * 2;
     }
 
     ff7_externals.engine_draw_sub_66A47E(wave_data_pointer);
@@ -74,14 +73,12 @@ void ifrit_first_wave_effect_widescreen_fix_sub_66A47E(int wave_data_pointer) {
 
 void ifrit_second_third_wave_effect_widescreen_fix_sub_66A47E(int wave_data_pointer) {
     if(aspect_ratio == AR_WIDESCREEN) {
-        constexpr int viewport_x_fix = -106;
-        constexpr int viewport_height_fix = 480 - 332;
-        constexpr int viewport_width_1_fix = 340 - 255;
-        constexpr int viewport_width_2_fix = 87 - 65;
-        *(short*)(wave_data_pointer + 8) += + viewport_x_fix + viewport_width_1_fix * 2;
-        *(short*)(wave_data_pointer + 16) += + viewport_x_fix + (viewport_width_1_fix + viewport_width_2_fix) * 2;
-        *(short*)(wave_data_pointer + 24) += + viewport_x_fix + viewport_width_1_fix * 2;
-        *(short*)(wave_data_pointer + 32) += + viewport_x_fix + (viewport_width_1_fix + viewport_width_2_fix) * 2;
+        int viewport_width_1_fix = ceil(255.f / game_width * wide_viewport_width) - 255;
+        int viewport_width_2_fix = ceil(65.f / game_width * wide_viewport_width) - 65;
+        *(short*)(wave_data_pointer + 8) += wide_viewport_x + viewport_width_1_fix * 2;
+        *(short*)(wave_data_pointer + 16) += wide_viewport_x + (viewport_width_1_fix + viewport_width_2_fix) * 2;
+        *(short*)(wave_data_pointer + 24) += wide_viewport_x + viewport_width_1_fix * 2;
+        *(short*)(wave_data_pointer + 32) += wide_viewport_x + (viewport_width_1_fix + viewport_width_2_fix) * 2;
     }
 
     ff7_externals.engine_draw_sub_66A47E(wave_data_pointer);

--- a/src/ff7/field.cpp
+++ b/src/ff7/field.cpp
@@ -33,6 +33,7 @@
 #include "../sfx.h"
 #include "../movies.h"
 #include "../common.h"
+#include "widescreen.h"
 #include "defs.h"
 #include <set>
 #include <cmath>
@@ -395,8 +396,8 @@ bool ff7_field_do_draw_3d_model(short x, short y)
 {
 	if(*ff7_externals.field_bg_flag_CC15E4)
 		return 1;
-	int left_offset_x = aspect_ratio == AR_WIDESCREEN ? 93 : 40;
-	int right_offset_x = aspect_ratio == AR_WIDESCREEN ? 453 : 400;
+	int left_offset_x = 40 + (aspect_ratio == AR_WIDESCREEN ? abs(wide_viewport_x) - 50 : 0);
+	int right_offset_x = 400 + (aspect_ratio == AR_WIDESCREEN ? abs(wide_viewport_x) - 50 : 0);
 	return x > ff7_externals.field_vector2_CFF204->x - left_offset_x && x < ff7_externals.field_vector2_CFF204->x + right_offset_x &&
 		y > ff7_externals.field_vector2_CFF204->y - 120 && y < ff7_externals.field_vector2_CFF204->y + 460;
 }
@@ -405,9 +406,9 @@ void ff7_field_set_fade_quad_size(int x, int y, int width, int height)
 {
 	if(aspect_ratio == AR_WIDESCREEN)
 	{
-		x -= 106;
+		x -= abs(wide_viewport_x);
 		y -= ff7_center_fields ? 16 : 0;
-		width += 213;
+		width += (wide_viewport_width - game_width);
 		height += 32;
 	}
 	ff7_externals.field_sub_63AC3F(x, y, width, height);
@@ -422,7 +423,7 @@ void field_clip_with_camera_range_float(vector2<float>* point)
 		int cameraRange = field_triggers_header_ptr->camera_range.right - field_triggers_header_ptr->camera_range.left;
 #if 1
 		// This only clips backgrounds which width is enought to fill the whole screen in 16:9
-		if(cameraRange >= 320 + 106) halfWidth = 213;
+		if(cameraRange >= game_width / 2 + abs(wide_viewport_x)) halfWidth = wide_viewport_width / 4;
 #else
 		// Currently disabled
 		// This tries to centers the background for fields which width is bigger than 320 but less than what is needed to fill the whole screen in 16:9
@@ -448,7 +449,7 @@ void float_sub_643628(field_trigger_header *trigger_header, vector2<float> *delt
 		int cameraRange = trigger_header->camera_range.right - trigger_header->camera_range.left;
 #if 1
 		// This only clips backgrounds which width is enought to fill the whole screen in 16:9
-		if(cameraRange > 320 + 106) halfWidth = 213;
+		if(cameraRange >= game_width / 2 + abs(wide_viewport_x)) halfWidth = wide_viewport_width / 4;
 #else
 		// Currently disabled
 		// This tries to centers the background for fields which width is bigger than 320 but less than what is needed to fill the whole screen in 16:9
@@ -621,7 +622,7 @@ void field_init_scripted_bg_movement()
 			*ff7_externals.scripted_world_move_step_index = 0;
 			world_pos = {*ff7_externals.field_curr_delta_world_pos_x, *ff7_externals.field_curr_delta_world_pos_y};
 
-			if(aspect_ratio = AR_WIDESCREEN)
+			if(aspect_ratio == AR_WIDESCREEN)
 				ff7_field_clip_with_camera_range(&world_pos);
 
 			*ff7_externals.scripted_world_initial_pos_x = world_pos.x;
@@ -632,7 +633,7 @@ void field_init_scripted_bg_movement()
 			*ff7_externals.field_bg_flag_CC15E4 = 1;
 
 			world_pos = {ff7_externals.modules_global_object->field_A, ff7_externals.modules_global_object->field_C};
-			if(aspect_ratio = AR_WIDESCREEN)
+			if(aspect_ratio == AR_WIDESCREEN)
 				ff7_field_clip_with_camera_range(&world_pos);
 
 			*ff7_externals.field_curr_delta_world_pos_x = world_pos.x;
@@ -646,14 +647,14 @@ void field_init_scripted_bg_movement()
 			*ff7_externals.scripted_world_move_step_index = 0;
 
 			world_pos = {*ff7_externals.field_curr_delta_world_pos_x, *ff7_externals.field_curr_delta_world_pos_y};
-			if(aspect_ratio = AR_WIDESCREEN)
+			if(aspect_ratio == AR_WIDESCREEN)
 				ff7_field_clip_with_camera_range(&world_pos);
 
 			*ff7_externals.scripted_world_initial_pos_x = world_pos.x;
 			*ff7_externals.scripted_world_initial_pos_y = world_pos.y;
 
 			world_pos = {ff7_externals.modules_global_object->field_A, ff7_externals.modules_global_object->field_C};
-			if(aspect_ratio = AR_WIDESCREEN)
+			if(aspect_ratio == AR_WIDESCREEN)
 				ff7_field_clip_with_camera_range(&world_pos);
 
 			*ff7_externals.scripted_world_final_pos_x = world_pos.x;

--- a/src/ff7/widescreen.cpp
+++ b/src/ff7/widescreen.cpp
@@ -1,0 +1,154 @@
+/****************************************************************************/
+//    Copyright (C) 2009 Aali132                                            //
+//    Copyright (C) 2018 quantumpencil                                      //
+//    Copyright (C) 2018 Maxime Bacoux                                      //
+//    Copyright (C) 2020 myst6re                                            //
+//    Copyright (C) 2020 Chris Rizzitello                                   //
+//    Copyright (C) 2020 John Pritchard                                     //
+//    Copyright (C) 2022 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2022 Tang-Tang Zhou                                     //
+//    Copyright (C) 2022 Cosmos                                             //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+#include "widescreen.h"
+#include "../patch.h"
+#include "../ff7.h"
+#include "cmath"
+
+int viewport_width_plus_x_widescreen_fix = 750;
+int swirl_framebuffer_offset_x_widescreen_fix = 106;
+int swirl_framebuffer_offset_y_widescreen_fix = 64;
+
+void ff7_widescreen_hook_init() {
+    // Field fix
+    replace_function((uint32_t)ff7_externals.field_clip_with_camera_range_6438F6, ff7_field_clip_with_camera_range);
+	replace_function(ff7_externals.field_layer3_clip_with_camera_range_643628, ff7_field_layer3_clip_with_camera_range);
+	replace_function(ff7_externals.field_culling_model_639252, ff7_field_do_draw_3d_model);
+	replace_call_function(ff7_externals.field_sub_63AC66 + 0xD5, ff7_field_set_fade_quad_size);
+
+    // Swirl fix
+    patch_code_dword(ff7_externals.swirl_loop_sub_4026D4 + 0x335, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.swirl_enter_sub_401810 + 0x21, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.swirl_enter_40164E + 0xEE, (uint32_t)&swirl_framebuffer_offset_x_widescreen_fix);
+    patch_code_dword(ff7_externals.swirl_enter_40164E + 0x112, (uint32_t)&swirl_framebuffer_offset_x_widescreen_fix);
+    patch_code_dword(ff7_externals.swirl_enter_40164E + 0xFB, (uint32_t)&swirl_framebuffer_offset_y_widescreen_fix);
+    patch_code_dword(ff7_externals.swirl_enter_40164E + 0x11F, (uint32_t)&swirl_framebuffer_offset_y_widescreen_fix);
+    patch_code_int(ff7_externals.swirl_enter_40164E + 0xE8, 85);
+
+    // Battle fix
+    patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x4B, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x68, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x8B, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.battle_sub_5BD050 + 0xB4, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x105, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x122, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x141, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x16A, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x19F, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x1BB, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.battle_enter + 0x229, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.battle_enter + 0x22F, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.battle_draw_quad_5BD473 + 0xDA, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.battle_draw_quad_5BD473 + 0x112, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.battle_sub_58ACB9 + 0x55, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.battle_sub_58ACB9 + 0x65, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.display_battle_damage_5BB410 + 0x23F, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.display_battle_damage_5BB410 + 0x24C, (uint32_t)&wide_viewport_x);
+    patch_code_int(ff7_externals.shadow_flare_draw_white_bg_57747E + 0x18, wide_viewport_x);
+    patch_code_int(ff7_externals.shadow_flare_draw_white_bg_57747E + 0x1F, wide_viewport_width / 2);
+    replace_call_function(ff7_externals.ifrit_sub_595A05 + 0x930, ifrit_first_wave_effect_widescreen_fix_sub_66A47E);
+    replace_call_function(ff7_externals.ifrit_sub_595A05 + 0xAEC, ifrit_second_third_wave_effect_widescreen_fix_sub_66A47E);
+    replace_call_function(ff7_externals.ifrit_sub_595A05 + 0xCC0, ifrit_second_third_wave_effect_widescreen_fix_sub_66A47E);
+    patch_code_int(ff7_externals.neo_bahamut_effect_sub_490F2A + 0x58, wide_viewport_width / 4);
+    patch_code_dword(ff7_externals.neo_bahamut_effect_sub_490F2A + 0x5D, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.neo_bahamut_effect_sub_490F2A + 0x6A, (uint32_t)&wide_viewport_x);
+    patch_code_int(ff7_externals.neo_bahamut_effect_sub_490F2A + 0x88, wide_viewport_width / 4);
+    patch_code_dword(ff7_externals.neo_bahamut_effect_sub_490F2A + 0x1A2, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.neo_bahamut_effect_sub_490F2A + 0x1AF, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x140, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x15B, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x19B, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x1D1, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x20E, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x243, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x28A, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x2C0, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x2FC, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x332, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.odin_gunge_effect_sub_4A3A2E + 0x38, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.odin_gunge_effect_sub_4A3A2E + 0x53, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.odin_gunge_effect_sub_4A4BE6 + 0x36, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.odin_gunge_effect_sub_4A4BE6 + 0x51, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.typhoon_effect_sub_4D7044 + 0x1B, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.typhoon_effect_sub_4D7044 + 0x36, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.typhoon_effect_sub_4DB15F + 0x22, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.typhoon_effect_sub_4DB15F + 0x3D, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.barret_limit_3_1_sub_4700F7 + 0x1B, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.barret_limit_3_1_sub_4700F7 + 0x36, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.fat_chocobo_sub_5096F3 + 0x4A, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.fat_chocobo_sub_5096F3 + 0x5F, (uint32_t)&wide_viewport_width);
+
+    // Worldmap fix
+    patch_code_dword(ff7_externals.world_draw_fade_quad_75551A + 0x12, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.world_draw_fade_quad_75551A + 0x1A3, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.world_draw_fade_quad_75551A + 0x2BE, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.world_draw_fade_quad_75551A + 0x331, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.world_draw_fade_quad_75551A + 0x4E8, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.world_draw_fade_quad_75551A + 0x54A, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.world_culling_bg_meshes_75F263 + 0xE, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.world_culling_bg_meshes_75F263 + 0x20, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.world_culling_bg_meshes_75F263 + 0x26, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.world_submit_draw_bg_meshes_75F68C + 0xAE, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.world_submit_draw_bg_meshes_75F68C + 0xB6, (uint32_t)&wide_viewport_x);
+    memset_code(ff7_externals.world_sub_751EFC + 0xC89, 0x90, 6);
+
+    patch_code_short(ff7_externals.world_compute_skybox_data_754100 + 0x174, -wide_viewport_width / 4 - 20);
+    patch_code_short(ff7_externals.world_compute_skybox_data_754100 + 0x1D1, wide_viewport_width / 4 + 20);
+    patch_code_short(ff7_externals.world_compute_skybox_data_754100 + 0x22E, -wide_viewport_width / 4 - 20);
+    patch_code_short(ff7_externals.world_compute_skybox_data_754100 + 0x282, wide_viewport_width / 4 + 20);
+    patch_code_byte(ff7_externals.world_compute_skybox_data_754100 + 0x180, 44);
+    patch_code_byte(ff7_externals.world_compute_skybox_data_754100 + 0x1DD, 44);
+    patch_code_short(ff7_externals.world_compute_skybox_data_754100 + 0x237, 20);
+    patch_code_short(ff7_externals.world_compute_skybox_data_754100 + 0x28B, 20);
+    patch_code_short(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x132, -256);
+    patch_code_int(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x144, 256);
+    patch_code_byte(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x15C, 0);
+    patch_code_short(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x16D, 256);
+    patch_code_int(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x2DC, 0);
+    patch_code_int(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x40F, 0);
+    patch_code_dword(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x5A5, (uint32_t)&wide_viewport_x); // Meteor avoid culling
+    patch_code_int(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x5B5, wide_viewport_width / 2); // Meteor avoid culling
+
+    // Gameover fix
+    patch_code_int(ff7_externals.enter_gameover + 0xA4, wide_viewport_x);
+    patch_code_int(ff7_externals.enter_gameover + 0xB8, wide_viewport_width);
+
+    // CDCheck fix
+    patch_code_int(ff7_externals.cdcheck_enter_sub + 0xB9, wide_viewport_x);
+    patch_code_int(ff7_externals.cdcheck_enter_sub + 0xCD, wide_viewport_width);
+
+    // Credits fix
+    patch_code_dword(ff7_externals.credits_submit_draw_fade_quad_7AA89B + 0x99, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.credits_submit_draw_fade_quad_7AA89B + 0xE6, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.credits_submit_draw_fade_quad_7AA89B + 0x133, (uint32_t)&viewport_width_plus_x_widescreen_fix);
+    patch_code_dword(ff7_externals.credits_submit_draw_fade_quad_7AA89B + 0x180, (uint32_t)&viewport_width_plus_x_widescreen_fix);
+
+    // Menu, endbattle menu, ... fixes
+    patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0x50, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0xA8, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0x105, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0x163, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0x111, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0x16F, (uint32_t)&wide_viewport_width);
+}

--- a/src/ff7/widescreen.h
+++ b/src/ff7/widescreen.h
@@ -1,0 +1,29 @@
+/****************************************************************************/
+//    Copyright (C) 2009 Aali132                                            //
+//    Copyright (C) 2018 quantumpencil                                      //
+//    Copyright (C) 2018 Maxime Bacoux                                      //
+//    Copyright (C) 2020 myst6re                                            //
+//    Copyright (C) 2020 Chris Rizzitello                                   //
+//    Copyright (C) 2020 John Pritchard                                     //
+//    Copyright (C) 2022 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2022 Tang-Tang Zhou                                     //
+//    Copyright (C) 2022 Cosmos                                             //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+#pragma once
+
+int wide_viewport_x = -106;
+int wide_viewport_width = 854;
+
+void ff7_widescreen_hook_init();

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -1120,6 +1120,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.world_sub_75079D = get_relative_call(ff7_externals.world_mode_loop_sub_74DB8C, 0x421);
 	ff7_externals.world_sub_751EFC = get_relative_call(ff7_externals.world_sub_75079D, 0x1FB);
 	ff7_externals.world_culling_bg_meshes_75F263 = get_relative_call(ff7_externals.world_sub_751EFC, 0x7C6);
+	ff7_externals.world_submit_draw_bg_meshes_75F68C = get_relative_call(ff7_externals.world_sub_751EFC, 0x7FD);
 	ff7_externals.world_compute_skybox_data_754100 = get_relative_call(ff7_externals.world_mode_loop_sub_74DB8C, 0x537);
 	ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 = get_relative_call(ff7_externals.world_mode_loop_sub_74DB8C, 0x547);
 

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -29,14 +29,10 @@
 #include "music.h"
 #include "ff7/defs.h"
 #include "ff7_data.h"
+#include "ff7/widescreen.h"
 
 unsigned char midi_fix[] = {0x8B, 0x4D, 0x14};
 WORD snowboard_fix[] = {0x0F, 0x10, 0x0F};
-int viewport_x_widescreen_fix = -106;
-int viewport_width_widescreen_fix = 856;
-int viewport_width_plus_x_widescreen_fix = 750;
-int swirl_framebuffer_offset_x_widescreen_fix = 106;
-int swirl_framebuffer_offset_y_widescreen_fix = 64;
 
 void ff7_init_hooks(struct game_obj *_game_object)
 {
@@ -237,123 +233,8 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	// #####################
 	// widescreen
 	// #####################
-	replace_function((uint32_t)ff7_externals.field_clip_with_camera_range_6438F6, ff7_field_clip_with_camera_range);
-	replace_function(ff7_externals.field_layer3_clip_with_camera_range_643628, ff7_field_layer3_clip_with_camera_range);
-	replace_function(ff7_externals.field_culling_model_639252, ff7_field_do_draw_3d_model);
-	replace_call_function(ff7_externals.field_sub_63AC66 + 0xD5, ff7_field_set_fade_quad_size);
-	if (aspect_ratio == AR_WIDESCREEN)
-	{
-		// Swirl fix
-		patch_code_dword(ff7_externals.swirl_loop_sub_4026D4 + 0x335, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.swirl_enter_sub_401810 + 0x21, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.swirl_enter_40164E + 0xEE, (uint32_t)&swirl_framebuffer_offset_x_widescreen_fix);
-		patch_code_dword(ff7_externals.swirl_enter_40164E + 0x112, (uint32_t)&swirl_framebuffer_offset_x_widescreen_fix);
-		patch_code_dword(ff7_externals.swirl_enter_40164E + 0xFB, (uint32_t)&swirl_framebuffer_offset_y_widescreen_fix);
-		patch_code_dword(ff7_externals.swirl_enter_40164E + 0x11F, (uint32_t)&swirl_framebuffer_offset_y_widescreen_fix);
-		patch_code_int(ff7_externals.swirl_enter_40164E + 0xE8, 85);
-
-		// Battle fix
-		patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x4B, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x68, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x8B, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.battle_sub_5BD050 + 0xB4, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x105, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x122, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x141, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x16A, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x19F, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x1BB, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.battle_enter + 0x229, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.battle_enter + 0x22F, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.battle_draw_quad_5BD473 + 0xDA, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.battle_draw_quad_5BD473 + 0x112, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.battle_sub_58ACB9 + 0x55, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.battle_sub_58ACB9 + 0x65, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.display_battle_damage_5BB410 + 0x23F, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.display_battle_damage_5BB410 + 0x24C, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_int(ff7_externals.shadow_flare_draw_white_bg_57747E + 0x18, -106);
-		patch_code_int(ff7_externals.shadow_flare_draw_white_bg_57747E + 0x1F, 427);
-		replace_call_function(ff7_externals.ifrit_sub_595A05 + 0x930, ifrit_first_wave_effect_widescreen_fix_sub_66A47E);
-		replace_call_function(ff7_externals.ifrit_sub_595A05 + 0xAEC, ifrit_second_third_wave_effect_widescreen_fix_sub_66A47E);
-		replace_call_function(ff7_externals.ifrit_sub_595A05 + 0xCC0, ifrit_second_third_wave_effect_widescreen_fix_sub_66A47E);
-		patch_code_int(ff7_externals.neo_bahamut_effect_sub_490F2A + 0x58, viewport_width_widescreen_fix / 4);
-		patch_code_dword(ff7_externals.neo_bahamut_effect_sub_490F2A + 0x5D, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.neo_bahamut_effect_sub_490F2A + 0x6A, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_int(ff7_externals.neo_bahamut_effect_sub_490F2A + 0x88, viewport_width_widescreen_fix / 4);
-		patch_code_dword(ff7_externals.neo_bahamut_effect_sub_490F2A + 0x1A2, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.neo_bahamut_effect_sub_490F2A + 0x1AF, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x140, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x15B, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x19B, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x1D1, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x20E, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x243, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x28A, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x2C0, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x2FC, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x332, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.odin_gunge_effect_sub_4A3A2E + 0x38, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.odin_gunge_effect_sub_4A3A2E + 0x53, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.odin_gunge_effect_sub_4A4BE6 + 0x36, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.odin_gunge_effect_sub_4A4BE6 + 0x51, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.typhoon_effect_sub_4D7044 + 0x1B, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.typhoon_effect_sub_4D7044 + 0x36, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.typhoon_effect_sub_4DB15F + 0x22, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.typhoon_effect_sub_4DB15F + 0x3D, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.barret_limit_3_1_sub_4700F7 + 0x1B, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.barret_limit_3_1_sub_4700F7 + 0x36, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.fat_chocobo_sub_5096F3 + 0x4A, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.fat_chocobo_sub_5096F3 + 0x5F, (uint32_t)&viewport_width_widescreen_fix);
-
-		// Worldmap fix
-		patch_code_dword(ff7_externals.world_draw_fade_quad_75551A + 0x12, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.world_draw_fade_quad_75551A + 0x1A3, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.world_draw_fade_quad_75551A + 0x2BE, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.world_draw_fade_quad_75551A + 0x331, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.world_draw_fade_quad_75551A + 0x4E8, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.world_draw_fade_quad_75551A + 0x54A, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.world_culling_bg_meshes_75F263 + 0xE, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.world_culling_bg_meshes_75F263 + 0x20, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.world_culling_bg_meshes_75F263 + 0x26, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_short(ff7_externals.world_compute_skybox_data_754100 + 0x174, -244);
-		patch_code_short(ff7_externals.world_compute_skybox_data_754100 + 0x1D1, 244);
-		patch_code_short(ff7_externals.world_compute_skybox_data_754100 + 0x22E, -244);
-		patch_code_short(ff7_externals.world_compute_skybox_data_754100 + 0x282, 244);
-		patch_code_byte(ff7_externals.world_compute_skybox_data_754100 + 0x180, 44);
-		patch_code_byte(ff7_externals.world_compute_skybox_data_754100 + 0x1DD, 44);
-		patch_code_short(ff7_externals.world_compute_skybox_data_754100 + 0x237, 20);
-		patch_code_short(ff7_externals.world_compute_skybox_data_754100 + 0x28B, 20);
-		patch_code_short(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x132, -256);
-		patch_code_int(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x144, 256);
-		patch_code_byte(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x15C, 0);
-		patch_code_short(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x16D, 256);
-		patch_code_int(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x2DC, 0);
-		patch_code_int(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x40F, 0);
-		patch_code_dword(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x5A5, (uint32_t)&viewport_x_widescreen_fix); // Meteor avoid culling
-		patch_code_int(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x5B5, 360); // Meteor avoid culling
-
-		// Gameover fix
-		patch_code_int(ff7_externals.enter_gameover + 0xA4, viewport_x_widescreen_fix);
-		patch_code_int(ff7_externals.enter_gameover + 0xB8, viewport_width_widescreen_fix);
-
-		// CDCheck fix
-		patch_code_int(ff7_externals.cdcheck_enter_sub + 0xB9, viewport_x_widescreen_fix);
-		patch_code_int(ff7_externals.cdcheck_enter_sub + 0xCD, viewport_width_widescreen_fix);
-
-		// Credits fix
-		patch_code_dword(ff7_externals.credits_submit_draw_fade_quad_7AA89B + 0x99, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.credits_submit_draw_fade_quad_7AA89B + 0xE6, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.credits_submit_draw_fade_quad_7AA89B + 0x133, (uint32_t)&viewport_width_plus_x_widescreen_fix);
-		patch_code_dword(ff7_externals.credits_submit_draw_fade_quad_7AA89B + 0x180, (uint32_t)&viewport_width_plus_x_widescreen_fix);
-
-		// Menu, endbattle menu, ... fixes
-		patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0x50, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0xA8, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0x105, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0x163, (uint32_t)&viewport_x_widescreen_fix);
-		patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0x111, (uint32_t)&viewport_width_widescreen_fix);
-		patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0x16F, (uint32_t)&viewport_width_widescreen_fix);
-	}
+	if(aspect_ratio == AR_WIDESCREEN)
+		ff7_widescreen_hook_init();
 
 	// #####################
 	// worldmap footsteps

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -1189,7 +1189,7 @@ void Renderer::setScissor(uint16_t x, uint16_t y, uint16_t width, uint16_t heigh
         // This sets a scissor offset for field with width not enough to fill the screen in 16:9
         struct game_mode* mode = getmode_cached();
         field_trigger_header* field_triggers_header_ptr = *ff7_externals.field_triggers_header;
-        if(mode->driver_mode == MODE_FIELD && field_triggers_header_ptr != nullptr)
+        if(mode->driver_mode == MODE_FIELD && *ff7_externals.field_level_data_pointer != 0)
         {
             int cameraRange = (field_triggers_header_ptr->camera_range.right - field_triggers_header_ptr->camera_range.left);
             if(cameraRange < game_width / 2 + abs(wide_viewport_x))


### PR DESCRIPTION
I refactor the hardcoded values into variables, but I didn't want to add another aspect ratio. It makes it too much complex. I only tested the 21:9 myself to see if it's possible; for now there is a limitation in worldmap for the clouds. Cannot cover the entire screen.

I also removed the option to change to widescreen using shift-right since it doesn't work well.