### PR TITLE
Widescreen: Add hook function just before draws related to text and text boxes

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2414,6 +2414,7 @@ struct ff7_externals
 	uint32_t *field_bg_multiplier;
 	void (*add_page_tile)(float, float, float, float, float, uint32_t, uint32_t);
 	double (*field_layer_sub_623C0F)(rotation_matrix*, int, int, int);
+	void (*field_draw_gray_quads_644E90)();
 	field_trigger_header** field_triggers_header;
 	rotation_matrix* field_camera_rotation_matrix_CFF3D8;
 	uint32_t field_load_textures;

--- a/src/ff7/widescreen.cpp
+++ b/src/ff7/widescreen.cpp
@@ -33,6 +33,13 @@ int swirl_framebuffer_offset_y_widescreen_fix = 64;
 
 Widescreen widescreen;
 
+// This function should be called at each frame after drawing backgrounds and 3d models
+void ff7_field_draw_gray_quads_sub_644E90() {
+    ff7_externals.field_draw_gray_quads_644E90();
+
+    ffnx_trace("FIELD: draw gray quads\n");
+}
+
 void ifrit_first_wave_effect_widescreen_fix_sub_66A47E(int wave_data_pointer) {
 	int viewport_width_1_fix = ceil(255.f / game_width * wide_viewport_width) - 255;
 	*(short*)(wave_data_pointer + 8) += wide_viewport_x;
@@ -80,6 +87,8 @@ void ff7_widescreen_hook_init() {
     memset_code(ff7_externals.field_submit_draw_pointer_hand_60D572 + 0x39, 0x90, 12); // Remove useless culling cursor
     patch_code_int(ff7_externals.field_init_viewport_values + 0xBE, wide_viewport_width + wide_viewport_x - 60);
     patch_code_int(ff7_externals.field_init_viewport_values + 0xC8, 18);
+    // For zoom field maps
+    replace_call_function(ff7_externals.field_draw_everything + 0x360, ff7_field_draw_gray_quads_sub_644E90);
 
     // Swirl fix
     patch_code_dword(ff7_externals.swirl_loop_sub_4026D4 + 0x335, (uint32_t)&wide_viewport_x);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -336,6 +336,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.add_page_tile = (void (*)(float, float, float, float, float, uint32_t, uint32_t))get_relative_call(ff7_externals.field_layer2_pick_tiles, 0x327);
 	ff7_externals.field_triggers_header = (field_trigger_header**)get_absolute_value(ff7_externals.field_layer3_pick_tiles, 0x134);
 	ff7_externals.field_camera_rotation_matrix_CFF3D8 = (rotation_matrix*)get_absolute_value(ff7_externals.field_layer3_pick_tiles, 0x7A);
+	ff7_externals.field_draw_gray_quads_644E90 = (void(*)())get_relative_call(ff7_externals.field_draw_everything, 0x360);
 
 	ff7_externals.field_load_textures = get_relative_call(ff7_externals.field_sub_60DCED, 0x107);
 	ff7_externals.field_convert_type2_layers = (void (*)())get_relative_call(ff7_externals.field_load_textures, 0xD);

--- a/src/lighting_debug.cpp
+++ b/src/lighting_debug.cpp
@@ -203,7 +203,7 @@ void lighting_debug(bool* isOpen)
     }
     if(ImGui::Button("Export widescreen config"))
     {
-        widescreen.exportConfig();
+        //widescreen.exportConfig();
     }
     ImGui::End();
 }


### PR DESCRIPTION
I hooked a function that draws some gray quads (which I don't know what is it), but it should be called each frame and done after backgrounds and 3d models