### PR TITLE
FF7: Add worldmap hooks and disable worldmap meshes draw calls

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2998,6 +2998,7 @@ struct ff7_externals
 	uint32_t world_mode_loop_sub_74DB8C;
 	uint32_t world_init_variables_74E1E9;
 	uint32_t world_sub_7641A7;
+	void (*world_init_load_wm_bot_block_7533AF)();
 	uint32_t run_world_event_scripts;
 	uint32_t run_world_event_scripts_system_operations;
 	uint32_t world_animate_all_models;
@@ -3057,6 +3058,7 @@ struct ff7_externals
 	int* world_unk_rotation_value_E045E0;
 	world_event_data** world_event_current_entity_ptr_E39AD8;
 	world_event_data** world_event_current_entity_ptr_E3A7CC;
+	int* world_progress_E28CB4;
 	int* is_wait_frames_zero_E39BC0;
 	int* world_prev_key_input_status_DFC470;
 	int* world_map_type_E045E8;
@@ -3077,7 +3079,9 @@ struct ff7_externals
 	uint32_t world_sub_75A1C6;
 	uint32_t world_load_graphics_objects_75A5D5;
 	uint32_t world_init_load_map_meshes_graphics_objects_75A283;
-	uint32_t world_wm0_overworld_draw_all_74C179;
+	void (*world_wm0_overworld_draw_all_74C179)();
+	void (*world_wm2_underwater_draw_all_74C3F0)();
+	void (*world_wm3_snowstorm_draw_all_74C589)();
 	uint32_t world_draw_fade_quad_75551A;
 	uint32_t world_sub_75079D;
 	uint32_t world_sub_751EFC;

--- a/src/ff7/world/renderer.cpp
+++ b/src/ff7/world/renderer.cpp
@@ -27,6 +27,22 @@
 
 namespace ff7::world {
 
+    void init_load_wm_bot_blocks() {
+        ff7_externals.world_init_load_wm_bot_block_7533AF();
+    }
+
+    void wm0_overworld_draw_all() {
+        ff7_externals.world_wm0_overworld_draw_all_74C179();
+    }
+
+    void wm2_underwater_draw_all() {
+        ff7_externals.world_wm2_underwater_draw_all_74C3F0();
+    }
+
+    void wm3_snowstorm_draw_all() {
+        ff7_externals.world_wm3_snowstorm_draw_all_74C589();
+    }
+
     // This draw call is the first UI call that marks the start of the first UI draw section
     void wm0_draw_minimap_quad_graphics_object(ff7_graphics_object* quad_graphics_object, ff7_game_obj* game_object) {
         newRenderer.setTimeFilterEnabled(false);

--- a/src/ff7/world/renderer.h
+++ b/src/ff7/world/renderer.h
@@ -27,6 +27,12 @@
 
 namespace ff7::world {
 
+    void init_load_wm_bot_blocks();
+
+    void wm0_overworld_draw_all();
+    void wm2_underwater_draw_all();
+    void wm3_snowstorm_draw_all();
+
     void wm0_draw_minimap_quad_graphics_object(ff7_graphics_object* quad_graphics_object, ff7_game_obj* game_object);
     void wm0_draw_world_effects_1_graphics_object(ff7_graphics_object* world_effects_1_graphics_object, ff7_game_obj* game_object);
     void wm0_draw_minimap_points_graphics_object(ff7_graphics_object* minimap_points_graphics_object, ff7_game_obj* game_object);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -1132,6 +1132,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	// World externals
 	ff7_externals.world_init_variables_74E1E9 = get_relative_call(ff7_externals.world_mode_loop_sub_74DB8C, 0x108);
 	ff7_externals.world_sub_7641A7 = get_relative_call(ff7_externals.world_mode_loop_sub_74DB8C, 0x210);
+	ff7_externals.world_init_load_wm_bot_block_7533AF = (void(*)())get_relative_call(ff7_externals.world_mode_loop_sub_74DB8C, 0x296);
 	ff7_externals.run_world_event_scripts = get_relative_call(ff7_externals.world_sub_7641A7, 0x1D);
 	ff7_externals.run_world_event_scripts_system_operations = get_relative_call(ff7_externals.run_world_event_scripts, 0xC7);
 	ff7_externals.pop_world_script_stack = (int(*)())get_relative_call(ff7_externals.run_world_event_scripts_system_operations, 0x44);
@@ -1192,6 +1193,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.world_unk_rotation_value_E045E0 = (int*)get_absolute_value(ff7_externals.world_update_player_74EA48, 0x972);
 	ff7_externals.world_event_current_entity_ptr_E39AD8 = (world_event_data**)get_absolute_value((uint32_t)ff7_externals.world_update_model_movement_762E87, 0x5);
 	ff7_externals.world_event_current_entity_ptr_E3A7CC = (world_event_data**)get_absolute_value(ff7_externals.run_world_event_scripts_system_operations, 0x8E6);
+	ff7_externals.world_progress_E28CB4 = (int*)get_absolute_value((uint32_t)ff7_externals.world_init_load_wm_bot_block_7533AF, 0xA1);
 	ff7_externals.is_wait_frames_zero_E39BC0 = (int*)get_absolute_value(ff7_externals.run_world_event_scripts_system_operations, 0xD46);
 	ff7_externals.world_prev_key_input_status_DFC470 = (int*)get_absolute_value(ff7_externals.world_update_player_74EA48, 0x35A);
 	ff7_externals.world_map_type_E045E8 = (int*)get_absolute_value(ff7_externals.world_update_player_74EA48, 0x66);
@@ -1212,7 +1214,9 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.world_sub_75A1C6 = get_relative_call(ff7_externals.world_init_variables_74E1E9, 0x3A);
 	ff7_externals.world_load_graphics_objects_75A5D5 = get_relative_call(ff7_externals.world_sub_75A1C6, 0x61);
 	ff7_externals.world_init_load_map_meshes_graphics_objects_75A283 = get_relative_call(ff7_externals.world_load_graphics_objects_75A5D5, 0x340);
-	ff7_externals.world_wm0_overworld_draw_all_74C179 = get_absolute_value(ff7_externals.world_init_load_map_meshes_graphics_objects_75A283, 0xA7);
+	ff7_externals.world_wm0_overworld_draw_all_74C179 = (void(*)())get_absolute_value(ff7_externals.world_init_load_map_meshes_graphics_objects_75A283, 0xA7);
+	ff7_externals.world_wm2_underwater_draw_all_74C3F0 = (void(*)())get_absolute_value(ff7_externals.world_init_load_map_meshes_graphics_objects_75A283, 0xDF);
+	ff7_externals.world_wm3_snowstorm_draw_all_74C589 = (void(*)())get_absolute_value(ff7_externals.world_init_load_map_meshes_graphics_objects_75A283, 0x117);
 	ff7_externals.world_draw_fade_quad_75551A = get_relative_call(ff7_externals.world_mode_loop_sub_74DB8C, 0x554);
 	ff7_externals.world_sub_75079D = get_relative_call(ff7_externals.world_mode_loop_sub_74DB8C, 0x421);
 	ff7_externals.world_sub_751EFC = get_relative_call(ff7_externals.world_sub_75079D, 0x1FB);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -306,6 +306,17 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	{
 		replace_function(ff7_externals.world_update_camera_74E8CE, ff7::world::update_world_camera);
 		replace_function(ff7_externals.world_update_player_74EA48, ff7::world::update_player_and_handle_input);
+
+		replace_call_function(ff7_externals.world_mode_loop_sub_74DB8C + 0x296, ff7::world::init_load_wm_bot_blocks);
+
+		patch_code_dword(ff7_externals.world_init_load_map_meshes_graphics_objects_75A283 + 0xA7, (DWORD)&ff7::world::wm0_overworld_draw_all);
+		patch_code_dword(ff7_externals.world_init_load_map_meshes_graphics_objects_75A283 + 0xDF, (DWORD)&ff7::world::wm2_underwater_draw_all);
+		patch_code_dword(ff7_externals.world_init_load_map_meshes_graphics_objects_75A283 + 0x117, (DWORD)&ff7::world::wm3_snowstorm_draw_all);
+
+		// Remove world meshes draw calls by jumping to end of loop
+		patch_code_byte((uint32_t)ff7_externals.world_wm0_overworld_draw_all_74C179 + 0x32, 0x76);
+		patch_code_byte((uint32_t)ff7_externals.world_wm2_underwater_draw_all_74C3F0 + 0x32, 0x2D);
+		patch_code_byte((uint32_t)ff7_externals.world_wm3_snowstorm_draw_all_74C589 + 0x32, 0x2D);
 	}
 
 	//######################
@@ -328,9 +339,9 @@ void ff7_init_hooks(struct game_obj *_game_object)
 		replace_call_function(ff7_externals.battle_draw_text_ui_graphics_objects_call, ff7::battle::draw_ui_graphics_objects_wrapper);
 		replace_call_function(ff7_externals.battle_draw_box_ui_graphics_objects_call, ff7::battle::draw_ui_graphics_objects_wrapper);
 
-		replace_call_function(ff7_externals.world_wm0_overworld_draw_all_74C179 + 0x175, ff7::world::wm0_draw_minimap_quad_graphics_object);
-		replace_call_function(ff7_externals.world_wm0_overworld_draw_all_74C179 + 0x1BE, ff7::world::wm0_draw_world_effects_1_graphics_object);
-		replace_call_function(ff7_externals.world_wm0_overworld_draw_all_74C179 + 0x208, ff7::world::wm0_draw_minimap_points_graphics_object);
+		replace_call_function((uint32_t)ff7_externals.world_wm0_overworld_draw_all_74C179 + 0x175, ff7::world::wm0_draw_minimap_quad_graphics_object);
+		replace_call_function((uint32_t)ff7_externals.world_wm0_overworld_draw_all_74C179 + 0x1BE, ff7::world::wm0_draw_world_effects_1_graphics_object);
+		replace_call_function((uint32_t)ff7_externals.world_wm0_overworld_draw_all_74C179 + 0x208, ff7::world::wm0_draw_minimap_points_graphics_object);
 	}
 
 	//#############################


### PR DESCRIPTION
- Got the worldmap progress variable
- Hooked the 3 draw all functions
- Hooked the function that load the initial block of WM
- Disable the draw calls related to worldmap terrain